### PR TITLE
Add Matrix links to page as Discord alternative

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -29,6 +29,7 @@ active: Home
             <li {% if title == "Home" %}class="active"{% endif %}><a href="{{ '/index.html' | url }}"><i class="fa-solid fa-house"></i> Home</a></li>
             <li><a href="https://github.com/waycrate/"><i class="fa-brands fa-github"></i> GitHub</a></li>
             <li><a href="https://discord.gg/KKZRDYrRYW"><i class="fa-brands fa-discord"></i> Discord</a></li>
+			<li><a href="https://matrix.to/#/#waycrate-tools:matrix.org"><i class="fa-solid fa-message"></i> Matrix</a></li>
           </ul>
         </nav>
 

--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ tty.
 ### Contributing
 
 We are accepting more contributors to our organization. If you are
-interested, join our [Discord server](https://discord.gg/KKZRDYrRYW).
+interested, you can either join our Matrix space at [#waycrate-tools:matrix.org](https://matrix.to/#/#waycrate-tools:matrix.org) or join our [Discord server](https://discord.gg/KKZRDYrRYW), depending on your preference.
 
 ### Our Supporters
 

--- a/swhkd/index.md
+++ b/swhkd/index.md
@@ -61,7 +61,7 @@ The default configuration directory is `/etc/swhkd/swhkdrc`. If you don't like h
 
 ## Support:
 
-For support, you can join [#swhkd:matrix.org](https://matrix.to/#/#swhkd:matrix.org) or our [Discord](https://discord.gg/KKZRDYrRYW), depending on your preference.
+For support, you can join [#swhkd:matrix.org](https://matrix.to/#/#swhkd:matrix.org) on Matrix, or our [Discord](https://discord.gg/KKZRDYrRYW), depending on your preference.
 
 ## Contributors:
 

--- a/swhkd/index.md
+++ b/swhkd/index.md
@@ -59,9 +59,9 @@ Swhkd closely follows sxhkd syntax, so most existing sxhkd configs should be fun
 
 The default configuration directory is `/etc/swhkd/swhkdrc`. If you don't like having to edit the file as root every single time, you can create a symlink from `~/.config/swhkd/swhkdrc` to `/etc/swhkd/swhkdrc`.
 
-## Support server:
+## Support:
 
-[Discord](https://discord.gg/KKZRDYrRYW)
+For support, you can join [#swhkd:matrix.org](https://matrix.to/#/#swhkd:matrix.org) or our [Discord](https://discord.gg/KKZRDYrRYW), depending on your preference.
 
 ## Contributors:
 

--- a/wayout/index.md
+++ b/wayout/index.md
@@ -55,4 +55,4 @@ wayout --toggle <your output name>
 
 1 - Use the mailing list.
 
-2 - You can also join our Matrix space ([#waycrate-tools:matrix.org](https://matrix.to/#/#waycrate-tools:matrix.org)), which is bridged to our [Discord server](https://discord.gg/KKZRDYrRYW), depending on which you prefer.
+2 - You can also join us on Matrix at ([#wayout:matrix.org](https://matrix.to/#/#waycrate-tools:matrix.org)), which is also bridged to our [Discord server](https://discord.gg/KKZRDYrRYW), depending on which you prefer.

--- a/wayout/index.md
+++ b/wayout/index.md
@@ -55,4 +55,4 @@ wayout --toggle <your output name>
 
 1 - Use the mailing list.
 
-2 - I don't endorse the usage of discord but if you really need it, then you can join the following <a href="https://discord.gg/KKZRDYrRYW">server</a> for support.
+2 - You can also join our Matrix space ([#waycrate-tools:matrix.org](https://matrix.to/#/#waycrate-tools:matrix.org)), which is bridged to our [Discord server](https://discord.gg/KKZRDYrRYW), depending on which you prefer.

--- a/wayshot/index.md
+++ b/wayshot/index.md
@@ -73,7 +73,7 @@ wayshot -s "$(slurp -p -f '%x %y %w %h')" --stdout | convert - -format '%[pixel:
 
 1 - Use the mailing list.
 
-2 - You can also join our Matrix space ([#waycrate-tools:matrix.org](https://matrix.to/#/#waycrate-tools:matrix.org)), which is bridged to our [Discord server](https://discord.gg/KKZRDYrRYW), depending on which you prefer.
+2 - You can also join us on Matrix at ([#wayshot:matrix.org](https://matrix.to/#/#waycrate-tools:matrix.org)), which is also bridged to our [Discord server](https://discord.gg/KKZRDYrRYW), depending on which you prefer.
 
 
 # Smithay Developers:

--- a/wayshot/index.md
+++ b/wayshot/index.md
@@ -73,7 +73,8 @@ wayshot -s "$(slurp -p -f '%x %y %w %h')" --stdout | convert - -format '%[pixel:
 
 1 - Use the mailing list.
 
-2 - I don't endorse the usage of Discord but if you really need it, then you can join the following <a href="https://discord.gg/KKZRDYrRYW">server</a> for support.
+2 - You can also join our Matrix space ([#waycrate-tools:matrix.org](https://matrix.to/#/#waycrate-tools:matrix.org)), which is bridged to our [Discord server](https://discord.gg/KKZRDYrRYW), depending on which you prefer.
+
 
 # Smithay Developers:
 


### PR DESCRIPTION
There are now multiple rooms and a space on Matrix for waycrate. This PR adds a link in the navigation column and the contributing section on the index page, as well as to the individual rooms on the respective application pages.