### PR TITLE
External links opening in a new tab

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -27,8 +27,8 @@ active: Home
         <nav>
           <ul>
             <li {% if title == "Home" %}class="active"{% endif %}><a href="{{ '/index.html' | url }}"><i class="fa-solid fa-house"></i> Home</a></li>
-            <li><a href="https://github.com/waycrate/"><i class="fa-brands fa-github"></i> GitHub</a></li>
-            <li><a href="https://discord.gg/KKZRDYrRYW"><i class="fa-brands fa-discord"></i> Discord</a></li>
+            <li><a href="https://github.com/waycrate/" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-github"></i> GitHub</a></li>
+            <li><a href="https://discord.gg/KKZRDYrRYW" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-discord"></i> Discord</a></li>
           </ul>
 
           <h3>GSoC 2024</h3>


### PR DESCRIPTION
**Issue:** Solving issue #20

External links for GitHub and Discord on the website currently open in the same browser tab, which can disrupt the user experience by navigating away from the site.

**Changes Made:**

Updated the HTML anchor tags for GitHub and Discord icons to include target="_blank" to ensure that these links open in a new browser tab.
Added rel="noopener noreferrer" to improve security and performance when opening links in a new tab.

**Affected Files:**
Modified the HTML file containing the links to GitHub and Discord.

**Testing:**

Clicked on the GitHub icon and verified that it opens in a new tab.
Clicked on the Discord icon and verified that it opens in a new tab.
Additional Notes:

These changes ensure that users can easily return to the website after visiting GitHub or Discord.